### PR TITLE
Bug fixes

### DIFF
--- a/src/graph/svg-renderer.ts
+++ b/src/graph/svg-renderer.ts
@@ -81,7 +81,7 @@ function preprocessVizSVG(svgString: string) {
     let [tag, ...restOfId] = $el.id.split('::');
     if (_.size(restOfId) < 1) return;
 
-    if ($el.id.match("^TYPE_TITLE.*APIs?")) {
+    if ($el.id.match("^TYPE_TITLE.*APIs?$")) {
       $el.classList.add("type-api");
     }
 

--- a/src/graph/viewport.ts
+++ b/src/graph/viewport.ts
@@ -180,6 +180,7 @@ export class Viewport {
   }
 
   focusElement(id: string) {
+    this.selectNodeById(id);
     let bbBox = document.getElementById(id).getBoundingClientRect();
     let currentPan = this.zoomer.getPan();
     let viewPortSizes = (<any>this.zoomer).getSizes();
@@ -270,6 +271,10 @@ function edgeFrom(id: String) {
 function edgesFromNode($node) {
   var edges = [];
   forEachNode($node, '.edge-source', ($source) => {
+    const $edge = edgeFrom($source.id);
+    edges.push($edge);
+  });
+  forEachNode($node, '.edge-source-api', ($source) => {
     const $edge = edgeFrom($source.id);
     edges.push($edge);
   });


### PR DESCRIPTION
In this merge, these bugs where fixed:
1) If the Schema Object had API in there name, the voyager used to treat it as an API and not an object.
![Screenshot from 2021-03-02 10-50-02](https://user-images.githubusercontent.com/46474357/109601550-1332fa80-7b45-11eb-9f5e-8c324ac4fdbc.png)
2) When a API was selected in the Voyager, it did not highlight the outgoing edge if the edge pointed to a object.
![Screenshot from 2021-03-02 10-52-25](https://user-images.githubusercontent.com/46474357/109601736-673ddf00-7b45-11eb-81b3-869229f4348d.png)
An enhancement was added:
1) While clicking on a foreign key link in Voyager, it used to zoom and pan on the linked object, but it never used to highlight it. This enhancement as been made.